### PR TITLE
Add `/charms` command

### DIFF
--- a/cogs/tibiawiki.py
+++ b/cogs/tibiawiki.py
@@ -18,6 +18,8 @@ from .utils.tibia import get_map_area
 from .utils.tibiawiki import get_item, get_monster, get_spell, get_achievement, get_npc, WIKI_ICON, get_article_url, \
     get_key, search_key, get_rashid_info, get_mapper_link, get_bestiary_classes, get_bestiary_creatures, get_imbuement
 
+WIKI_TITLE_CYCLOPEDIA_CHARMS = "Cyclopedia#List_of_Charms"
+
 
 class TibiaWiki:
     """Commands that show information about Tibia, provided by TibiaWiki.
@@ -88,33 +90,72 @@ class TibiaWiki:
     @checks.can_embed()
     @commands.command()
     async def charms(self, ctx: NabCtx):
-        """Displays a list of all charms for the user to choose.
-
-        After a charm is specified, uses the database information to display details about the chosen charm."""
+        """Displays summary information of all charms currently available in the database."""
         charms = self._get_all_charms()
-        chosen_name = await ctx.choose(list(charms.keys()), "", False)
-        if chosen_name:
-            charm = charms[chosen_name]
-            embed = await self._get_charms_embed(charm)
-            if ctx.bot_permissions.attach_files and charm["image"] is not None:
-                await self._send_embed_charms_with_image(charm, ctx, embed)
-            else:
-                await ctx.send(embed=embed)
+        embed = await self._get_charms_embed(charms)
+        await ctx.send(embed=embed)
+
+    async def _get_charms_embed(self, charms):
+        embed = discord.Embed(title="List of Charms", url=get_article_url(WIKI_TITLE_CYCLOPEDIA_CHARMS))
+        charms_by_type = self._get_charms_by_type(charms)
+        for charm_type in sorted(charms_by_type, reverse=True):
+            charms = charms_by_type[charm_type]
+            msg = []
+            for charm in charms:
+                msg.append("**" + charm["name"] + "** - " + str(charm["points"]))
+            embed.add_field(name=charm_type, value="\n".join(msg))
+        self._set_embed_author(embed, {"title": WIKI_TITLE_CYCLOPEDIA_CHARMS})
+        return embed
 
     @staticmethod
-    async def _send_embed_charms_with_image(charm, ctx, embed):
+    def _get_charms_by_type(charms):
+        charms_by_type = {}
+        for charm in charms.values():
+            if not charm["type"] in charms_by_type.keys():
+                charms_by_type[charm["type"]] = []
+            charms_by_type[charm["type"]].append(charm)
+        return charms_by_type
+
+    @checks.can_embed()
+    @commands.command()
+    async def charm(self, ctx: NabCtx, name: str=None):
+        """If no name is specified, displays a list of all charms for the user to choose from.
+        If name is given and valid, or if one is chosen from the list, displays detailed information about it."""
+        charms = self._get_all_charms()
+        chosen_name = None
+        if not name:
+            chosen_name = await ctx.choose(list(charms.keys()), "", False)
+            if not chosen_name:
+                return
+        else:
+            for key in charms.keys():
+                if key.lower() == name.lower():
+                    chosen_name = key
+                    break
+            if not chosen_name:
+                await ctx.send("Invalid name. You can check all available ones with `/charms`.")
+                return
+
+        charm = charms[chosen_name]
+        embed = await self._get_charm_embed(charm)
+        if ctx.bot_permissions.attach_files and charm["image"] is not None:
+            await self._send_embed_charm_with_image(charm, ctx, embed)
+        else:
+            await ctx.send(embed=embed)
+
+    @staticmethod
+    async def _send_embed_charm_with_image(charm, ctx, embed):
         filename = re.sub(r"[^A-Za-z0-9]", "", charm["name"]) + ".png"
         embed.set_thumbnail(url=f"attachment://{filename}")
         main_color = await ctx.execute_async(average_color, charm["image"])
         embed.color = discord.Color.from_rgb(*main_color)
         await ctx.send(file=discord.File(charm["image"], f"{filename}"), embed=embed)
 
-    async def _get_charms_embed(self, charm):
-        article_title = "Cyclopedia#List_of_Charms"
-        embed = discord.Embed(title=charm["name"], url=get_article_url(article_title))
+    async def _get_charm_embed(self, charm):
+        embed = discord.Embed(title=charm["name"], url=get_article_url(WIKI_TITLE_CYCLOPEDIA_CHARMS))
         embed.description = "**Type**: %s | **Cost**: %s points" % (charm["type"], charm["points"])
         embed.add_field(name="Description", value=charm["description"])
-        self._set_embed_author(embed, {"title": article_title})
+        self._set_embed_author(embed, {"title": WIKI_TITLE_CYCLOPEDIA_CHARMS})
         return embed
 
     @staticmethod

--- a/cogs/utils/context.py
+++ b/cogs/utils/context.py
@@ -133,7 +133,7 @@ class NabCtx(commands.Context):
         return ask_channel.name
 
     # endregion
-    async def choose(self, matches: Sequence[Any], title="Suggestions"):
+    async def choose(self, matches: Sequence[Any], title="Suggestions", not_found=True):
         if len(matches) == 0:
             raise ValueError('No results found.')
 
@@ -143,8 +143,11 @@ class NabCtx(commands.Context):
         embed = discord.Embed(colour=discord.Colour.blurple(), title=title,
                               description='\n'.join(f'{index}: {item}' for index, item in enumerate(matches, 1)))
 
-        msg = await self.send("I couldn't find what you were looking for, maybe you mean one of these?\n"
-                              "**Only say the number** (*0 to cancel*)", embed=embed)
+        suggestion_text = "Please choose one of the options.\n"
+        not_found_text = "I couldn't find what you were looking for, maybe you mean one of these?\n"
+        cancel_text = "**Only say the number** (*0 to cancel*)"
+        text = not_found_text + cancel_text if not_found else suggestion_text + cancel_text
+        msg = await self.send(text, embed=embed)
 
         def check(m: discord.Message):
             return m.content.isdigit() and m.author.id == self.author.id and m.channel.id == self.channel.id


### PR DESCRIPTION
User can run `/charms` which will list all available and, after choosing one, detailed information is shown.

Improved message in `/choose` to allow for using it in more cases.