### PR TITLE
Update Tibia.com URLs

### DIFF
--- a/cogs/tibia.py
+++ b/cogs/tibia.py
@@ -758,7 +758,7 @@ class Tibia:
                         break
                     if row["world"] not in user_worlds:
                         continue
-                        
+
                     user = self._get_cached_user_(self, row["user_id"], user_cache, user_servers)
                     if user is None:
                         continue
@@ -1726,7 +1726,7 @@ class Tibia:
             await ctx.send("I'm having connection issues right now.")
             return
 
-        url = 'https://secure.tibia.com/community/?subtopic=worlds&world=' + name.capitalize()
+        url = 'https://www.tibia.com/community/?subtopic=worlds&world=' + name.capitalize()
         embed = discord.Embed(url=url, title=name.capitalize())
         if world.online == 0:
             embed.description = "This world is offline."
@@ -1881,7 +1881,7 @@ class Tibia:
         reply += ". {0.he_she} has {0.achievement_points:,} achievement points.".format(char)
 
         if char.guild is not None:
-            guild_url = url_guild+urllib.parse.quote(char.guild_name)
+            guild_url = url_guild + urllib.parse.quote(char.guild_name)
             reply += "\n{0.he_she} is __{1}__ of the [{2}]({3}).".format(char,
                                                                          char.guild_rank,
                                                                          char.guild_name,

--- a/cogs/utils/tibia.py
+++ b/cogs/utils/tibia.py
@@ -27,13 +27,12 @@ ERROR_DOESNTEXIST = 1
 ERROR_NOTINDATABASE = 2
 
 # Tibia.com URLs:
-url_character = "https://secure.tibia.com/community/?subtopic=characters&name="
-url_guild = "https://secure.tibia.com/community/?subtopic=guilds&page=view&GuildName="
-url_guild_online = "https://secure.tibia.com/community/?subtopic=guilds&page=view&onlyshowonline=1&"
-url_house = "https://secure.tibia.com/community/?subtopic=houses&page=view&houseid={id}&world={world}"
-url_highscores = "https://secure.tibia.com/community/?subtopic=highscores&world={0}&list={1}&profession={2}&currentpage={3}"
+url_character = "https://www.tibia.com/community/?subtopic=characters&name="
+url_guild = "https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName="
+url_house = "https://www.tibia.com/community/?subtopic=houses&page=view&houseid={id}&world={world}"
+url_highscores = "https://www.tibia.com/community/?subtopic=highscores&world={0}&list={1}&profession={2}&currentpage={3}"
 
-tibia_logo = "http://static.tibia.com/images/global/general/apple-touch-icon-72x72.png"
+tibia_logo = "https://ssl-static-tibia.akamaized.net/images/global/general/apple-touch-icon-72x72.png"
 
 KNIGHT = ["knight", "elite knight", "ek", "k", "kina", "eliteknight", "elite"]
 PALADIN = ["paladin", "royal paladin", "rp", "p", "pally", "royalpaladin", "royalpally"]
@@ -89,8 +88,6 @@ class Character:
 
     FREE_ACCOUNT = 0
     PREMIUM_ACCOUNT = 1
-
-    URL_CHAR = "https://secure.tibia.com/community/?subtopic=characters&name="
 
     def __init__(self, name: str, world: str, **kwargs):
         self.name = name
@@ -170,7 +167,7 @@ class Character:
         :param name: Name of the character
         :return: url of the character's information
         """
-        return cls.URL_CHAR + urllib.parse.quote(name.encode('iso-8859-1'))
+        return url_character + urllib.parse.quote(name.encode('iso-8859-1'))
 
     @classmethod
     def parse_from_tibiadata(cls, content_json: Dict):
@@ -369,7 +366,7 @@ class Guild:
 
     @classmethod
     def get_url(cls, name: str) -> str:
-        """Returns the url pointing to the character's tibia.com page
+        """Returns the URL pointing to the character's tibia.com page
 
         :param name: Name of the character
         :return: url of the character's information
@@ -515,7 +512,7 @@ async def get_character(name, tries=5, *, bot: commands.Bot=None) -> Optional[Ch
                                                                                                  result["guild"]))
             if bot is not None:
                 bot.dispatch("character_change", character.owner)
-        
+
     return character
 
 


### PR DESCRIPTION
As of a couple of months ago, there’s no longer a need to use `https://secure.tibia.com/` since `https://www.tibia.com/` now works just the same. In fact, this is what the website itself uses in its links nowadays. This patch makes NabBot follow the same URL format.