### PR TITLE
Migration improvements

### DIFF
--- a/cogs/utils/database.py
+++ b/cogs/utils/database.py
@@ -13,14 +13,14 @@ wiki_db = sqlite3.connect(f"file:{WIKIDB}?mode=ro", uri=True)
 wiki_db.row_factory = sqlite3.Row
 
 # Pattern to match the number of affected rows
-result_patt = re.compile(r"\w+\s(\d+)")
+result_patt = re.compile(r"(\d+)$")
 
 PoolConn = Union[asyncpg.pool.Pool, asyncpg.Connection]
 
 
 def get_affected_count(result: str) -> int:
-    """Gets the number of affected rows by a UPDATE or DELETE query."""
-    m = result_patt.search(result)
+    """Gets the number of affected rows by a UPDATE, DELETE or INSERT queries."""
+    m = result_patt.search(result.strip())
     if not m:
         return 0
     return int(m.group(1))
@@ -175,35 +175,37 @@ class DbChar(tibiapy.abc.BaseCharacter):
             return cls(**row)
 
     @classmethod
-    async def get_chars_by_user(cls, conn: PoolConn, user: Union[int, discord.User, discord.Member],
-                                worlds: Union[List[str], str] = None) -> List['DbChar']:
+    async def get_chars_by_user(cls, conn: PoolConn, user_id=0, *, worlds: Union[List[str], str] = None) \
+            -> List['DbChar']:
         """Gets a list of characters registered to a user
 
         :param conn: A connection pool or single connection to the database.
-        :param user: The user or user id to check.
+        :param user_id: The user or user id to check.
         :param worlds: Whether to filter out chars not in the provided worlds.
         :return: The list of characters registered to the user.
         """
-        if not isinstance(user, int):
-            user = user.id
-        rows = await conn.fetch('SELECT * FROM "character" WHERE user_id = $1', user)
-        if not rows:
-            return []
-        chars = [cls(**row) for row in rows]
         if isinstance(worlds, str):
             worlds = [worlds]
-        if worlds:
-            return list(filter(lambda c: c.world in worlds, chars))
-        return chars
+        if worlds is None:
+            worlds = []
+        rows = await conn.fetch("""SELECT * FROM "character"
+                                   WHERE user_id = $1 AND (cardinality($2::text[]) = 0 OR world = any($2))""",
+                                user_id, worlds)
+        if not rows:
+            return []
+        return [cls(**row) for row in rows]
 
 
 class DbLevelUp:
     """Represents a level up in the database."""
+    char: Optional[DbChar]
+
     def __init__(self, **kwargs):
         self.id = kwargs.get("id", 0)
         self.char_id = kwargs.get("character_id", 0)
         self.level = kwargs.get("level", 0)
         self.date = kwargs.get("date")
+        self.char = None
 
     def __repr__(self):
         return f"<{self.__class__.__name__} id={self.id} char_id={self.char_id} level={self.level}, date={self.date!r}>"
@@ -225,3 +227,32 @@ class DbLevelUp:
             row_id = await conn.fetchval("""INSERT INTO character_levelup(character_id, level, date) VALUES($1, $2, $3)
                                             RETURNING id""", char_id, level, date)
         return cls(id=row_id, character_id=char_id, level=level, date=date)
+
+    @classmethod
+    async def get_latest(cls, conn: PoolConn, minimum_level=0, *, user_id=0, worlds: Union[List[str], str] = None):
+        """Gets an asynchronous generator of the character's levelups.
+
+        :param conn: Connection to the database.
+        :param minimum_level: The minimum level to show.
+        :param user_id: The id of an user to only show level ups of characters they own.
+        :param worlds: A list of worlds to only show level ups of characters in that world.
+        :return: An asynchronous generator containing the levels.
+        """
+        if isinstance(worlds, str):
+            worlds = [worlds]
+        if not worlds:
+            worlds = []
+        async with conn.transaction():
+            async for row in conn.cursor("""SELECT l.*, c.name, c.level as char_level, c.world, c.vocation, c.user_id,
+                                            c.id as char_id, c.guild, c.sex
+                                            FROM character_levelup l
+                                            LEFT JOIN "character" c ON c.id = l.character_id
+                                            WHERE ($1::bigint = 0 OR c.user_id = $1) AND 
+                                            (cardinality($2::text[]) = 0 OR c.world = any($2))
+                                            AND l.level >= $3 
+                                            ORDER BY date DESC""", user_id, worlds, minimum_level):
+                level_up = DbLevelUp(**row)
+                level_up.char = DbChar(id=row["user_id"], name=row['name'], level=row['char_level'],
+                                       user_id=row["user_id"], world=row["world"], sex=row["sex"],
+                                       vocation=row["vocation"], guild=row["guild"])
+                yield level_up

--- a/launcher.py
+++ b/launcher.py
@@ -118,42 +118,37 @@ def migrate(path):
     """Migrates a v1.x.x SQLite to a PostgreSQL database.
 
     This is a time consuming operation and caution must be taken.
-    The original SQLite file is not affected.
-
-    Some checks are performed to avoid duplicates, but migrating more than one database may have unintended effects."""
-    log.info("Starting migration")
+    The original SQLite file is not affected."""
     loop = asyncio.get_event_loop()
     pool: asyncpg.pool.Pool = loop.run_until_complete(create_pool(get_uri(), command_timeout=60))
     if pool is None:
         log.error('Could not set up PostgreSQL. Exiting.')
         return
 
+    async def get_db_name(pool):
+        return await pool.fetchval("SELECT current_database()")
+
+    db_name = loop.run_until_complete(get_db_name(pool))
+
+    confirm = click.confirm("Migrating a SQL database requires an empty PostgreSQL database.\n"
+                            f"Confirming will delete all data from the database '{db_name}'.\n"
+                            f"The SQL database located in {path} will be imported afterwards."
+                            "Are you sure you want to continue? This action is irreversible.")
+    if not confirm:
+        click.echo("Operation aborted.")
+        return
+
+    click.echo("Clearing database...")
+    loop.run_until_complete(drop_tables(pool))
+    click.echo("Done!")
+
+    log.info("Starting migration")
     result = loop.run_until_complete(check_database(pool))
     if not result:
         log.error('Failed to check database')
         return
 
     loop.run_until_complete(import_legacy_db(pool, path))
-
-
-@main.command()
-def empty():
-    """Empties out the database.
-
-    Drops all tables from the saved PostgreSQL database.
-    This action is irreversible, so use with caution."""
-    confirm = click.confirm("Are you sure you want to drop all tables? This action is irreversible.")
-    if not confirm:
-        click.echo("Operation aborted.")
-
-    loop = asyncio.get_event_loop()
-    pool: asyncpg.pool.Pool = loop.run_until_complete(create_pool(get_uri(), command_timeout=60))
-    if pool is None:
-        log.error('Could not set up PostgreSQL. Exiting.')
-        return
-    click.echo("Clearing database...")
-    loop.run_until_complete(drop_tables(pool))
-    click.echo("Done!")
 
 
 if __name__ == "__main__":

--- a/nabbot.py
+++ b/nabbot.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import asyncpg
@@ -90,7 +89,6 @@ class NabBot(commands.Bot):
                                        member.id, guild.id)
 
         log.info("Bot is online and ready")
-        log.debug("Debug mode enabled.")
 
     async def on_message(self, message: discord.Message):
         """Called every time a message is sent on a visible channel."""


### PR DESCRIPTION
Migrating a sqlite database was a really long task, taking up to half an hour to migrate the current database (14k chars, 377k level ups, 127k deaths)

A brief explanation of how I was doing things before and after:

## Before
1. Iterate through SQLite character records, inserting one by one to PGSQL, saving the new created id
    - If a name conflict was found, the duplicate entry is ignored, but its id is saved to join with the original entry
    - A pair of queries are executed inside the loop to get the character's death and levelups, gathering a list, associated to their new id
1. Deaths are sorted by date, in ascending order
1. Iterate through every death
    - For every iteration, query the new database, to check if the death already exists, ignore if it does
    - Execute an insert query for every non-conflicting death.
1. Level ups are sorted by date, in ascending order
1. Iterate through every level up
    - For every iteration, query the new database, to check if the level up already exists, using a 15 second margin
    - Execute an insert query for every non-conflicting level up.

*The rest of the migration process contains very few data compared to the rest and it probably won't be optimized... much*

## After
1. Remove duplicate characters from old database, merging their child rows
1. Remove duplicate deaths and orphaned deaths
1. Remove duplicate level ups and orphaned level ups
1. Iterate characters on sqlite
    - Generate a mapping of character names to old character ids, e.g. `"Galarzaa Fidera" -> 1`
   - A list of tuples with character data is generated
1. List of tuples is passed to the `copy_records_to_table` function, and does a bulk insert (*this is the real performance gain*)
1. The new characters table is fetched entirely
1. The results are iterated, to generate a mapping of the old character id to the new character id, for instance, if Tschas had the id 243, and in the migrated data it now has the id 231, what the mapping does is associate `243 -> 231`
1. Iterate SQL deaths to gather their data in list of tuples
    - The id map is used to find to what character id the death belongs to in the new data.
    - Since in the new database, deaths have a child table called `character_death_killers`, we have an incrementing variable that assigns the death's id to the killer entry. This has no way to know if death ids didn't start at 1 or a death wasn't saved for some reason, potentially messing all data.
1. Use  `copy_records_to_table` to bulk insert deaths
1. Use  `copy_records_to_table` to bulk insert death killers
1. Iterate SQL level ups to gather their data in list of tuples
    - The id map is used to find to what character id the level up belongs to in the new data.
1. Use  `copy_records_to_table` to bulk insert level ups.

The new changes, can reduce the time from 5,400 seconds to as little as 20 seconds.