### PR TITLE
 Fix trailing/leading empty spaces breaking normalize vocation

### DIFF
--- a/cogs/calculators.py
+++ b/cogs/calculators.py
@@ -270,11 +270,11 @@ class Calculators:
         elif len(params) == 2:
             try:
                 level = int(params[0])
-                vocation = params[1].strip()
+                vocation = params[1]
             except ValueError:
                 try:
                     level = int(params[1])
-                    vocation = params[0].strip()
+                    vocation = params[0]
                 except ValueError:
                     await ctx.send(invalid_arguments)
                     return

--- a/cogs/calculators.py
+++ b/cogs/calculators.py
@@ -5,7 +5,7 @@ import math
 import discord
 from discord.ext import commands
 
-from cogs.utils import config, timing
+from cogs.utils import config, timing, split_params
 from nabbot import NabBot
 from .utils import tibia
 from .utils.context import NabCtx
@@ -258,8 +258,8 @@ class Calculators:
         """
         invalid_arguments = "Invalid arguments, examples:\n" \
                             f"```{ctx.clean_prefix}stats player\n" \
-                            f"{ctx.clean_prefix}stats level,vocation\n```"
-        params = params.split(",")
+                            f"{ctx.clean_prefix}stats level, vocation\n```"
+        params = split_params(params)
         char = None
         if len(params) == 1:
             char = await get_character(ctx.bot, params[0])

--- a/cogs/calculators.py
+++ b/cogs/calculators.py
@@ -270,7 +270,7 @@ class Calculators:
         elif len(params) == 2:
             try:
                 level = int(params[0])
-                vocation = params[1]
+                vocation = params[1].strip()
             except ValueError:
                 try:
                     level = int(params[1])

--- a/cogs/calculators.py
+++ b/cogs/calculators.py
@@ -274,7 +274,7 @@ class Calculators:
             except ValueError:
                 try:
                     level = int(params[1])
-                    vocation = params[0]
+                    vocation = params[0].strip()
                 except ValueError:
                     await ctx.send(invalid_arguments)
                     return

--- a/cogs/tibia.py
+++ b/cogs/tibia.py
@@ -19,7 +19,7 @@ from tibiawikisql import models
 
 from nabbot import NabBot
 from .utils import CogUtils, checks, config, errors, get_time_diff, get_user_avatar, is_numeric, \
-    join_list, online_characters, timing
+    join_list, online_characters, timing, split_params
 from .utils.context import NabCtx
 from .utils.database import DbChar, DbDeath, DbLevelUp, get_global_property, get_recent_timeline, get_server_property, \
     set_global_property
@@ -475,7 +475,7 @@ class Tibia(CogUtils):
         if params is None:
             params = []
         else:
-            params = params.split(",")
+            params = split_params(params)
         world = ctx.world
         if params and params[0].strip().title() in tibia_worlds:
             world = params[0].strip().title()
@@ -897,7 +897,7 @@ class Tibia(CogUtils):
             await ctx.send(f"A level {level} can share experience with levels **{low}** to **{high}**.")
             return
         except ValueError:
-            chars = param.split(",")
+            chars = split_params(param)
             if len(chars) > 5:
                 return await ctx.error("I can only check up to 5 characters at a time.")
             if len(chars) == 1:

--- a/cogs/tibiawiki.py
+++ b/cogs/tibiawiki.py
@@ -14,7 +14,7 @@ from tibiawikisql import models
 
 from cogs.utils.converter import TibiaNumber
 from nabbot import NabBot
-from .utils import FIELD_VALUE_LIMIT, average_color, checks, config, join_list
+from .utils import FIELD_VALUE_LIMIT, average_color, checks, config, join_list, split_params
 from .utils.context import NabCtx
 from .utils.database import wiki_db
 from .utils.errors import CannotPaginate
@@ -125,7 +125,7 @@ class TibiaWiki:
 
         It can also accept prices using the 'k' suffix, e.g. 1.5k
         """
-        params = params.split(",")
+        params = split_params(params)
         if len(params) > 5:
             await ctx.send(f"{ctx.tick(False)} Invalid syntax. The correct syntax is: `{ctx.usage}`.")
             return

--- a/cogs/tracking.py
+++ b/cogs/tracking.py
@@ -15,7 +15,7 @@ from tibiapy import Death, Guild, OnlineCharacter, OtherCharacter, World
 
 from nabbot import NabBot
 from .utils import CogUtils, EMBED_LIMIT, FIELD_VALUE_LIMIT, checks, config, get_user_avatar, is_numeric, join_list, \
-    online_characters, safe_delete_message
+    online_characters, safe_delete_message, split_params
 from .utils.context import NabCtx
 from .utils.database import DbChar, DbDeath, DbLevelUp, get_affected_count, get_server_property, PoolConn
 from .utils.errors import CannotPaginate, NetworkError
@@ -908,7 +908,7 @@ class Tracking(CogUtils):
         per_page = 20 if await ctx.is_long() else 5
 
         char = None
-        params = params.split(",")
+        params = split_params(params)
         if len(params) < 1 or len(params) > 2:
             await ctx.send(invalid_arguments)
             return

--- a/cogs/utils/__init__.py
+++ b/cogs/utils/__init__.py
@@ -283,6 +283,20 @@ async def safe_delete_message(message: discord.Message) -> bool:
         return False
 
 
+def split_params(param: str, delimiter=",", maxsplit=-1) -> List[str]:
+    """Splits the string parameter of a function and removes trailing/leading empty spaces from each resulting string.
+
+    :param param: The string to be split.
+    :param delimiter: The delimiter to be used for the split.
+    :param maxsplit Maximum amount of splits to be done.
+    :return: The list containing all stripped strings resulting from the split."""
+    split = param.split(delimiter, maxsplit)
+    params = []
+    for s in split:
+        params.append(s.strip())
+    return params
+
+
 def single_line(string: str) -> str:
     """Turns a multi-line string into a single.
 


### PR DESCRIPTION
`/stats 100, druid` would break as vocation was ` druid` and not `druid` (notice trailing/leading empty space).